### PR TITLE
BACKLOG-21353 Fix problem with replace on Windows by deactivating globs

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,19 +93,19 @@ try {
         files: targetFiles,
         from: /\$\$CAMEL_MODULE_NAME\$\$/g,
         to: camelProjectName,
-        disableGlobs : true // This is required otherwise the replaces fail under Windows (see https://jira.jahia.org/browse/BACKLOG-21353)
+        disableGlobs: true // This is required otherwise the replaces fail under Windows (see https://jira.jahia.org/browse/BACKLOG-21353)
     });
     replace.sync({
         files: targetFiles,
         from: /\$\$MODULE_NAME\$\$/g,
         to: projectName,
-        disableGlobs : true // This is required otherwise the replaces fail under Windows (see https://jira.jahia.org/browse/BACKLOG-21353)
+        disableGlobs: true // This is required otherwise the replaces fail under Windows (see https://jira.jahia.org/browse/BACKLOG-21353)
     });
     replace.sync({
         files: targetFiles,
         from: /\$\$MODULE_NAMESPACE\$\$/g,
         to: namespace,
-        disableGlobs : true // This is required otherwise the replaces fail under Windows (see https://jira.jahia.org/browse/BACKLOG-21353)
+        disableGlobs: true // This is required otherwise the replaces fail under Windows (see https://jira.jahia.org/browse/BACKLOG-21353)
     });
 } catch (error) {
     console.error('Error occurred:', error);


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-21353

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->
Disactivated globs support in files paths (we weren't using them anyway) because they fail with Windows path characters.
