### PR TITLE
BACKLOG-22316 - Add settings folder to NPX project & BACKLOG-22301 - Add support for auto-completion for VSCode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,9 @@ test-project
 test-project-hbs
 test-project-jsx
 .idea
-.yarn
+.yarn/cache
+.yarn/install-state.gz
+.yarn/unplugged
 .pnp*
 .yarnrc.yml
 **.tgz

--- a/handlebars/package.json
+++ b/handlebars/package.json
@@ -7,11 +7,14 @@
     "deploy": "jahia-deploy",
     "watch": "yarn build --env deploy=true --watch",
     "lint": "eslint .",
-    "test": "yarn lint"
+    "test": "yarn lint", 
+    "postinstall": "yarn dlx @yarnpkg/sdks vscode"    
   },
   "jahia": {
+    "module-dependencies" : "default",
     "module-type": "templatesSet",
-    "server": "dist/main.js"
+    "server": "dist/main.js", 
+    "static-resources" : "/css,/images,/javascript"
   },
   "devDependencies": {
     "@jahia/eslint-config": "^2.1.2",
@@ -22,13 +25,14 @@
     "eslint-plugin-react-hooks": "latest",
     "extra-watch-webpack-plugin": "latest",
     "handlebars-loader": "^1.7.3",
+    "typescript": "^5.3.3",
     "webpack": "^5.88.1",
     "webpack-cli": "^5.1.4",
     "webpack-shell-plugin-next": "^2.3.1"
   },
   "dependencies": {
     "handlebars": "^4.7.7",
-    "@jahia/js-server-engine" : "^1.1.0"
+    "@jahia/js-server-engine" : "^1.2.2"
   },
   "engines": {
     "node": ">=16.0.0",

--- a/handlebars/settings/README.txt
+++ b/handlebars/settings/README.txt
@@ -1,0 +1,9 @@
+In this directory you can put directly : 
+- Rule files (*.drl, *.dsl)
+- URL rewrite XML files
+
+In the configurations directory you can put : 
+- OSGi configuration files (*.cfg, *.yml)
+
+In the jahia-content-editor-forms you can put content editor form and field set overrides, 
+see examples here : https://academy.jahia.com/documentation/jahia/jahia-8/developer/extending-and-customizing-jahia-ui/customizing-content-editor-forms/examples-of-content-definition-json-overrides 

--- a/index.js
+++ b/index.js
@@ -95,6 +95,15 @@ if (process.argv[3] === 'handlebars') {
     );
 }
 
+// Create empty directories for static resources and configurations
+fs.mkdirSync(path.join(projectDir, 'css'), {recursive: true});
+fs.mkdirSync(path.join(projectDir, 'images'), {recursive: true});
+fs.mkdirSync(path.join(projectDir, 'javascript'), {recursive: true});
+fs.mkdirSync(path.join(projectDir, 'settings/configurations'), {recursive: true});
+fs.mkdirSync(path.join(projectDir, 'settings/jahia-content-editor-forms'), {recursive: true});
+fs.mkdirSync(path.join(projectDir, 'settings/jahia-content-editor-forms/forms'), {recursive: true});
+fs.mkdirSync(path.join(projectDir, 'settings/jahia-content-editor-forms/fieldsets'), {recursive: true});
+
 // Find and replace all markers with the appropriate substitution values
 const targetFiles = [
     path.join(projectDir, 'README.md'),

--- a/jsx/package.json
+++ b/jsx/package.json
@@ -8,11 +8,14 @@
     "deploy": "jahia-deploy pack",
     "watch": "yarn build --env deploy=true --watch",
     "lint": "eslint .",
-    "test": "yarn lint"
+    "test": "yarn lint", 
+    "postinstall": "yarn dlx @yarnpkg/sdks vscode"    
   },
   "jahia": {
+    "module-dependencies" : "default",
     "module-type": "templatesSet",
-    "server": "dist/main.js"
+    "server": "dist/main.js",
+    "static-resources" : "/css,/images,/javascript"
   },
   "dependencies": {
     "@apollo/client": "3.5.5",
@@ -38,6 +41,7 @@
     "eslint-plugin-react-hooks": "latest",
     "extra-watch-webpack-plugin": "^1.0.3",
     "styled-jsx": "^5.1.2",
+    "typescript": "^5.3.3",
     "webpack": "^5.64.4",
     "webpack-cli": "^4.9.1",
     "webpack-shell-plugin-next": "^2.3.1"
@@ -46,5 +50,5 @@
     "node": ">=16.0.0",
     "yarn": ">=3.0.0"
   },
-  "packageManager": "yarn@4.0.1"
+  "packageManager": "yarn@4.1.0"
 }

--- a/jsx/settings/README.txt
+++ b/jsx/settings/README.txt
@@ -1,0 +1,9 @@
+In this directory you can put directly : 
+- Rule files (*.drl, *.dsl)
+- URL rewrite XML files
+
+In the configurations directory you can put : 
+- OSGi configuration files (*.cfg, *.yml)
+
+In the jahia-content-editor-forms you can put content editor form and field set overrides, 
+see examples here : https://academy.jahia.com/documentation/jahia/jahia-8/developer/extending-and-customizing-jahia-ui/customizing-content-editor-forms/examples-of-content-definition-json-overrides 


### PR DESCRIPTION

<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-22316
https://jira.jahia.org/browse/BACKLOG-22301

## Description

- Add settings (with configurations & content form overrides) as well as css, images and javascript folders to NPX project creation
- Add typescript dev dependency & postinstall script to install VS Code Yarn SDK that brings proper support for PnP auto-completion. ZipFS must still be installed manually in VS Code but it should be suggested by the configuration
- Update projects to Yarn 4.1.0

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->
