### PR TITLE
Add a platform check to run a platform specific sleep command in watc…

### DIFF
--- a/jsx/webpack.config.js
+++ b/jsx/webpack.config.js
@@ -142,6 +142,7 @@ module.exports = (env, mode) => {
     // Also an additional sleep is added to avoid watch triggering too much in a short time
     // (Feel free to adjust the sleep time according to your needs)
     if (mode.watch) {
+        // Sleep time in seconds, can be adjusted
         const sleepTime = 5;
 
         configs.push({


### PR DESCRIPTION
Description

I had a platform error on the precedent sleep command. So I added a platform check to run the good command (sleep or timeout) in function of the platform.

Tests

Pull Luxe and follow the "Build and deploy" section of the readme.

The project should run, deploy, and the watch command should not have error when making changes.
