### PR TITLE
BACKLOG-23250:Rename jahia-content-editor-forms -> content-editor-forms

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,23 +74,23 @@ fs.renameSync(
 
 // Rename the resource file to use the project name
 fs.renameSync(
-    path.join(projectDir, 'settings/resources/MODULE_NAME.properties'),
-    path.join(projectDir, 'settings/resources/' + projectName + '.properties')
+    path.join(projectDir, 'settings', 'resources', 'MODULE_NAME.properties'),
+    path.join(projectDir, 'settings', 'resources', projectName + '.properties')
 );
 
 fs.renameSync(
-    path.join(projectDir, 'settings/resources/MODULE_NAME_fr.properties'),
-    path.join(projectDir, 'settings/resources/' + projectName + '_fr.properties')
+    path.join(projectDir, 'settings', 'resources', 'MODULE_NAME_fr.properties'),
+    path.join(projectDir, 'settings', 'resources', projectName + '_fr.properties')
 );
 
 // Create empty directories for static resources and configurations
 fs.mkdirSync(path.join(projectDir, 'css'), {recursive: true});
 fs.mkdirSync(path.join(projectDir, 'images'), {recursive: true});
 fs.mkdirSync(path.join(projectDir, 'javascript'), {recursive: true});
-fs.mkdirSync(path.join(projectDir, 'settings/configurations'), {recursive: true});
-fs.mkdirSync(path.join(projectDir, 'settings/jahia-content-editor-forms'), {recursive: true});
-fs.mkdirSync(path.join(projectDir, 'settings/jahia-content-editor-forms/forms'), {recursive: true});
-fs.mkdirSync(path.join(projectDir, 'settings/jahia-content-editor-forms/fieldsets'), {recursive: true});
+fs.mkdirSync(path.join(projectDir, 'settings', 'configurations'), {recursive: true});
+fs.mkdirSync(path.join(projectDir, 'settings', 'content-editor-forms'), {recursive: true});
+fs.mkdirSync(path.join(projectDir, 'settings', 'content-editor-forms', 'forms'), {recursive: true});
+fs.mkdirSync(path.join(projectDir, 'settings', 'content-editor-forms', 'fieldsets'), {recursive: true});
 
 // Find and replace all markers with the appropriate substitution values
 const targetFiles = `${projectDir}/**`;


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-23250

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->
Rename the folder `jahia-content-editor-forms/` to `content-editor-forms/` to be aligned with the changes made in https://github.com/Jahia/npm-modules-engine/pull/181.
Also, use `path.join()` for building paths to ensure OS compatibility.
