### PR TITLE
BACKLOG-23224: Enable snapshot mode by default

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -12,6 +12,7 @@
     "test": "yarn lint"
   },
   "jahia": {
+    "snapshot": true,
     "module-dependencies": "default",
     "module-type": "$$MODULE_TYPE$$",
     "module-type-comment": "Use templatesSet in the module type to declare a template set",


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-23224

## Description

Enable snapshot mode (`.jahia.snapshot` in `package.json`) by default for projects generated with the `npx @jahia/create-module@latest` command.

