### PR TITLE
BACKLOG-23502 : fixes

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,6 @@ import path from 'path';
 import {fileURLToPath} from 'url';
 import {replaceInFileSync} from 'replace-in-file';
 import camelCase from 'camelcase';
-import {execSync} from 'child_process';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -34,8 +33,6 @@ where
 
 // First let's do some version checks
 console.log('Node version detected:', process.versions.node);
-const yarnVersion = execSync('yarn --version', {encoding: 'utf8'});
-console.log('Yarn version:', yarnVersion);
 
 // Create a project directory with the project name.
 const currentDir = process.cwd();
@@ -130,11 +127,8 @@ fs.mkdirSync(path.join(projectDir, 'settings', 'content-editor-forms'), {recursi
 fs.mkdirSync(path.join(projectDir, 'settings', 'content-editor-forms', 'forms'), {recursive: true});
 fs.mkdirSync(path.join(projectDir, 'settings', 'content-editor-forms', 'fieldsets'), {recursive: true});
 
-// Add the latest @jahia/javascript-modules-library
-execSync('yarn add @jahia/javascript-modules-library', {cwd: projectDir});
-const javascriptModulesLibraryInfo = execSync('yarn info @jahia/javascript-modules-library version --json', {cwd: projectDir, encoding: 'utf8'});
-const javascriptModulesLibraryInfoValue = JSON.parse(javascriptModulesLibraryInfo).value;
-console.log(`Added ${javascriptModulesLibraryInfoValue} to the project`);
+// Add an empty yarn.lock in case any parent folder is using yarn
+fs.writeFileSync(path.join(projectDir, 'yarn.lock'), '', 'utf8');
 
 console.log(`Created \x1B[1m${projectName}\x1B[0m at \x1B[1m${projectDir}\x1B[0m`);
 console.log('Success! Your new project is ready.');

--- a/template/package.json
+++ b/template/package.json
@@ -22,6 +22,7 @@
     "static-resources": "/icons,/images,/javascript,/locales"
   },
   "dependencies": {
+    "@jahia/javascript-modules-library": "0.x || ^1.0.0",
     "graphql": "^16.7.1",
     "i18next": "^23.10.1",
     "react": "^18.2.0",

--- a/tests/create-templatesSet-project.test.js
+++ b/tests/create-templatesSet-project.test.js
@@ -58,7 +58,8 @@ describe('npx @jahia/create-module', () => {
             'static/javascript',
             'settings/configurations',
             'settings/content-editor-forms/forms',
-            'settings/content-editor-forms/fieldsets'
+            'settings/content-editor-forms/fieldsets',
+            'yarn.lock'
         ];
         if (moduleType === 'templatesSet') {
             // This file should only exist for templates set


### PR DESCRIPTION
- remove yarn usage when creating a new project
- provide  **@jahia/javascript-modules-library** in version 0.x to 2.x (not included)
- provide an empty yarn.lock (this in case a parent folder contains a yarn.lock)